### PR TITLE
`<photo-booth>` performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.7] - 2024-06-30
+
+### Changed
+- No longer store items to pre-render in a `Map`
+- Ensure resources are properly freed on stop/disconnect
+- Text elements now have their own slot
+
+### Fixed
+- Abort rendering / `requestAnimationFrame` on `stop(0)`
+
 ## [v0.3.6] - 2024-06-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/components",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/components",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/components",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A collection of custom elements / web components",
   "private": false,
   "type": "module",


### PR DESCRIPTION
### Changed
- No longer store items to pre-render in a `Map`
- Ensure resources are properly freed on stop/disconnect
- Text elements now have their own slot

### Fixed
- Abort rendering / `requestAnimationFrame` on `stop(0)`

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
